### PR TITLE
Make theme switch clickthrough

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -2,35 +2,29 @@
     <a class="navbar-brand" href="{{ site.baseurl }}/">
         <img src="{{ site.baseurl }}/assets/images/logo_green.png" width="40" id="logo-header">
     </a>
-        <ul class="navbar-nav">
-            <li class="nav-item">
-                <b><a class="nav-link" href="{{ site.baseurl }}/blog">Blog</a></b>
-            </li>
-        </ul>
-        <ul class="navbar-nav">
-            <li class="nav-item">
-                <b><a class="nav-link" href="{{ site.baseurl }}/gallery">Gallery</a></b>
-            </li>
-        </ul>
-        <ul class="navbar-nav">
-            <li class="nav-item">
-                <b><a class="nav-link" href="{{ site.baseurl }}/contact">Contact</a></b>
-            </li>
-        </ul>
+    <ul class="navbar-nav">
+        <li class="nav-item">
+            <b><a class="nav-link" href="{{ site.baseurl }}/blog">Blog</a></b>
+        </li>
+    </ul>
+    <ul class="navbar-nav">
+        <li class="nav-item">
+            <b><a class="nav-link" href="{{ site.baseurl }}/gallery">Gallery</a></b>
+        </li>
+    </ul>
+    <ul class="navbar-nav">
+        <li class="nav-item">
+            <b><a class="nav-link" href="{{ site.baseurl }}/contact">Contact</a></b>
+        </li>
+    </ul>
 
-        <ul class="navbar-nav ml-auto">
-            <li class="nav-item">
-                <b><a class="nav-link" href="https://paypal.me/donadigos" target="_blank">PayPal Donation</a></b>
-            </li>
-        </ul>
+    <ul class="navbar-nav ml-auto">
+        <li class="nav-item">
+            <b><a class="nav-link" href="https://paypal.me/donadigos" target="_blank">PayPal Donation</a></b>
+        </li>
+    </ul>
 </nav>
 
-<nav class="navbar fixed-top navbar-expand-md" style="margin-top: 100px;">
-    <div class="container-fluid">
-        <div class="navbar-header">
-        </div>
-        <ul class="nav navbar-nav navbar-right">
-            <button id="theme-toggle" class="btn btn-primary" onclick="switchTheme()">Dark Mode</button>
-        </ul>
-    </div>
-</nav>
+<div class="fixed-top d-flex flex-row-reverse mr-4" style="margin-top: 100px; z-index: 0">
+    <button id="theme-toggle" class="btn btn-primary" onclick="switchTheme()">Light Mode</button>
+</div>


### PR DESCRIPTION
This commit fixes a bug where it was not possible to click through any
content that was at the same horizontal position as the "Light Mode/Dark
Mode" toggle, because the navbar has a higher z-index.

This happens for example when you have the toggle at the same height as the
GitHub/Twitter/etc links.

This could probably have been fixed by just setting the navbar to a z-index of 0 or set `pointer-events: none` somewhere,
but I thought simplifying it into a flex div also made a bit more sense, but happy
to change just the navbar too.

The content does not clip the button any more than it did before. I wasn't sure how to
deploy this to my own testing env, so I did most of the changes in my browser to test them
on the real website.

The rest of the changes are indentation fixes.